### PR TITLE
Fix app key subcommand name in CLI

### DIFF
--- a/docs/includes/_tigris_cloud.mdx
+++ b/docs/includes/_tigris_cloud.mdx
@@ -46,7 +46,7 @@ The next step is to generate credentials to be used by the application we
 will be building in this quickstart
 
 ```shell
-tigris create application quickstart "quickstart application"
+tigris create app_key quickstart "quickstart application"
 ```
 
 Once the command is executed, it would create the application credentials


### PR DESCRIPTION
There's no subcommand named `application` under `create` command in the latest tigris CLI version