### PR TITLE
Add pagination documentation to collection search

### DIFF
--- a/docs/sdkstools/typescript/_search-paginate.mdx
+++ b/docs/sdkstools/typescript/_search-paginate.mdx
@@ -1,0 +1,269 @@
+## Paginating through search results
+
+### Using page numbers {#using-page-number}
+
+To retrieve a page of results, you can simply use `search(query, page)` method
+with page number and page size. Following query fetches the first page of
+results with page size set as **10**
+
+```ts
+const query: SearchQuery<Catalog> = {
+  q: "running",
+  hitsPerPage: 10, // Optional. Defaults to 20
+};
+const result: SearchResult<Catalog> = await catalog.search(query, 1);
+
+console.log(result);
+```
+
+<details>
+  <summary>Output</summary>
+
+```
+  {
+    "hits": [
+      {
+        "document": {
+          "brand": "adidas",
+          "price": 35,
+          "review": {
+            "author": "olivia",
+            "rating": 7.5
+          },
+          "popularity": 7,
+          "id": "6",
+          "labels": "clothing",
+          "name": "running shorts"
+        },
+        "meta": {
+          "createdAt": "2023-03-13T21:42:35.000Z",
+          "textMatch": {
+            "fields": [
+              "name"
+            ],
+            "score": "578730123365187697"
+          }
+        }
+      },
+      {
+        "document": {
+          "id": "5",
+          "brand": "nike",
+          "name": "running shoes",
+          "price": 89,
+          "labels": "shoes",
+          "popularity": 10,
+          "review": {
+            "rating": 8.5,
+            "author": "olivia"
+          }
+        },
+        "meta": {
+          "createdAt": "2023-03-13T21:42:35.000Z",
+          "textMatch": {
+            "fields": [
+              "name"
+            ],
+            "score": "578730123365187697"
+          }
+        }
+      }
+    ],
+    "facets": {},
+    "meta": {
+      "found": 23,
+      "totalPages": 3,
+      "page": {
+        "current": 1,
+        "size": 10
+      },
+      "matchedFields": [
+        "name"
+      ]
+    }
+  }
+```
+
+</details>
+
+The `hitsPerPage` parameter controls the number of documents to include in a
+result page. The returned array of documents is accessible under `hits` key
+along with some search metadata.
+
+```ts
+console.log(result.hits);
+```
+
+<details>
+  <summary>Output</summary>
+
+```
+  [
+    {
+      "document": {
+        "labels": "clothing",
+        "popularity": 7,
+        "id": "6",
+        "name": "running shorts",
+        "review": {
+          "rating": 7.5,
+          "author": "olivia"
+        },
+        "price": 35,
+        "brand": "adidas"
+      },
+      "meta": {
+        "createdAt": "2023-03-13T21:42:07.000Z",
+        "textMatch": {
+          "fields": [
+            "name"
+          ],
+          "score": "578730123365187697"
+        }
+      }
+    },
+    {
+      "document": {
+        "name": "running shoes",
+        "id": "5",
+        "price": 89,
+        "popularity": 10,
+        "review": {
+          "author": "olivia",
+          "rating": 8.5
+        },
+        "brand": "nike",
+        "labels": "shoes"
+      },
+      "meta": {
+        "createdAt": "2023-03-13T21:42:07.000Z",
+        "textMatch": {
+          "fields": [
+            "name"
+          ],
+          "score": "578730123365187697"
+        }
+      }
+    }
+  ]
+```
+
+</details>
+
+Additionally, search result contains `meta` object having current page and total
+pages along with other information.
+
+```ts
+console.log(result.meta);
+```
+
+<details>
+  <summary>Output</summary>
+
+```
+  {
+    "found": 23,
+    "totalPages": 3,
+    "page": {
+      "current": 1,
+      "size": 10
+    },
+    "matchedFields": [
+      "name"
+    ]
+  }
+```
+
+</details>
+
+### Infinite scrolling
+
+Infinite scrolling also loads data in pages, it is just that the UX is more
+fluid. Instead of using page number, an Iterator object can be obtained from
+`search()` method call and processed iteratively.
+
+```ts
+const query: SearchQuery<Catalog> = {
+  q: "running",
+  hitsPerPage: 10, // Optional. Defaults to 20
+};
+
+const resultIterable: SearchIterator<Catalog> = await catalog.search(query);
+
+for await (const result of resultIterable) {
+  console.log(result);
+}
+```
+
+<details>
+  <summary>Output</summary>
+
+```
+  {
+    "hits": [
+      {
+        "document": {
+          "brand": "adidas",
+          "price": 35,
+          "review": {
+            "author": "olivia",
+            "rating": 7.5
+          },
+          "popularity": 7,
+          "id": "6",
+          "labels": "clothing",
+          "name": "running shorts"
+        },
+        "meta": {
+          "createdAt": "2023-03-13T21:42:35.000Z",
+          "textMatch": {
+            "fields": [
+              "name"
+            ],
+            "score": "578730123365187697"
+          }
+        }
+      },
+      {
+        "document": {
+          "id": "5",
+          "brand": "nike",
+          "name": "running shoes",
+          "price": 89,
+          "labels": "shoes",
+          "popularity": 10,
+          "review": {
+            "rating": 8.5,
+            "author": "olivia"
+          }
+        },
+        "meta": {
+          "createdAt": "2023-03-13T21:42:35.000Z",
+          "textMatch": {
+            "fields": [
+              "name"
+            ],
+            "score": "578730123365187697"
+          }
+        }
+      }
+    ],
+    "facets": {},
+    "meta": {
+      "found": 23,
+      "totalPages": 3,
+      "page": {
+        "current": 1,
+        "size": 10
+      },
+      "matchedFields": [
+        "name"
+      ]
+    }
+  }
+```
+
+</details>
+
+As you can see, the iterator returns the same `SearchResult` object as in
+[previous section](#using-page-number) with pagination metadata.

--- a/docs/sdkstools/typescript/database/search.mdx
+++ b/docs/sdkstools/typescript/database/search.mdx
@@ -41,8 +41,4 @@ import SearchPagination, {
 
 <SearchPagination />
 
-[//]:
-  #
-  "workaround to generate table of contents, see https://github.com/facebook/docusaurus/issues/3915"
-
 export const toc = [...searchToc, ...searchPaginationToc];

--- a/docs/sdkstools/typescript/database/search.mdx
+++ b/docs/sdkstools/typescript/database/search.mdx
@@ -18,6 +18,9 @@ import multipleSortFieldsSource from "!!raw-loader!../_snippets/search/_multiple
 import includeFieldsSource from "!!raw-loader!../_snippets/search/_includeFields";
 import excludeFieldsSource from "!!raw-loader!../_snippets/search/_excludeFields";
 import searchUsingCollationSource from "!!raw-loader!../_snippets/search/_searchUsingCollation";
+import SearchPagination, {
+  toc as searchPaginationToc,
+} from "../_search-paginate.mdx";
 
 <SearchTemplate
   codeLang="typescript"
@@ -36,6 +39,10 @@ import searchUsingCollationSource from "!!raw-loader!../_snippets/search/_search
   searchUsingCollation={searchUsingCollationSource}
 />
 
-[//]: # "workaround to generate table of contents, see https://github.com/facebook/docusaurus/issues/3915"
+<SearchPagination />
 
-export const toc = [...searchToc];
+[//]:
+  #
+  "workaround to generate table of contents, see https://github.com/facebook/docusaurus/issues/3915"
+
+export const toc = [...searchToc, ...searchPaginationToc];


### PR DESCRIPTION
The pagination documentation is missing in the database search section. This PR adds the missing documentation.