### PR TITLE
Fixed TypeError caused by incorrect varabled names with TigrisClient and ClientConfig

### DIFF
--- a/docs/concepts/vector-search/python/index.mdx
+++ b/docs/concepts/vector-search/python/index.mdx
@@ -43,9 +43,9 @@ from tigrisdb.client import TigrisClient
 from tigrisdb.types import ClientConfig
 
 client = TigrisClient(
-            config=ClientConfig(
+            conf=ClientConfig(
               server_url=<region uri here>,
-              project_name="vectordemo",
+              project="vectordemo",
               client_id=<client id here>,
               client_secret=<client secret here>
         )).get_search()


### PR DESCRIPTION
From issue *"Python Vector search client example results in TypeError #413"* 

When following the steps on the python vector search [Getting Started](https://www.tigrisdata.com/docs/concepts/vector-search/python/) page. [Step 3](https://www.tigrisdata.com/docs/concepts/vector-search/python/#3-create-the-vector-database-client) attempts to show the user how to build a client using the following code:
```python
from tigrisdb.client import TigrisClient
from tigrisdb.types import ClientConfig

client = TigrisClient(
            config=ClientConfig(
              server_url=<region uri here>,
              project_name="vectordemo",
              client_id=<client id here>,
              client_secret=<client secret here>
        )).get_search()
```

However this will result in the following traceback:
```
Traceback (most recent call last):
  File "path/to/client_test.py", line 19, in <module>
    config=ClientConfig(
           ^^^^^^^^^^^^^
TypeError: ClientConfig.__init__() got an unexpected keyword argument 'project_name'
```
### This is a caused by two problems: 
1.  The [ClientConfig](https://github.com/tigrisdata/tigris-client-python/blob/667d484dd4c6159a7e55a6e70c8a5cf3a23c3971/tigrisdb/types/__init__.py#LL11C5-L11C12) object is expecting the variable `project` not `project_name` as specified in the docs.
2. The [TigrisClient](https://github.com/tigrisdata/tigris-client-python/blob/667d484dd4c6159a7e55a6e70c8a5cf3a23c3971/tigrisdb/client.py#LL23C1-L23C70) is expecting a `conf` argument not `config` as specified in the docs

My **proposed solution** would be to change the [step three](https://www.tigrisdata.com/docs/concepts/vector-search/python/#3-create-the-vector-database-client) snippet to:
```python
from tigrisdb.client import TigrisClient
from tigrisdb.types import ClientConfig

client = TigrisClient(
            conf=ClientConfig(
              server_url=<region uri here>,
              project="vectordemo",
              client_id=<client id here>,
              client_secret=<client secret here>
        )).get_search()
```
