### PR TITLE
Fix outdated doc

### DIFF
--- a/docs/quickstarts/quickstart-go.mdx
+++ b/docs/quickstarts/quickstart-go.mdx
@@ -45,12 +45,12 @@ import (
 // User is a declaration of the model for the collection
 type User struct {
 	tigris.Model
-	Name    string
+	Name    string `tigris:"searchIndex"`
 	Balance float64
 }
 
 func main() {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	// Connect to the Tigris backend, create the database and collection if they don't exist,
@@ -59,8 +59,9 @@ func main() {
 		URL:          "your_tigris_uri",
 		ClientID:     "your_client_id_here",
 		ClientSecret: "your_client_secret_here",
+		Project:      "quickstart",
 	}
-	db, err := tigris.OpenDatabase(ctx, cfg, "hello_db", &User{})
+	db, err := tigris.OpenDatabase(ctx, cfg, &User{})
 	if err != nil {
 		panic(err)
 	}

--- a/docs/sdkstools/cli/configuration.md
+++ b/docs/sdkstools/cli/configuration.md
@@ -6,14 +6,14 @@ Tigris CLI utility reads configuration both from config files and environment va
 
 Utility loads configuration from the following locations in the given order:
 
-1. /etc/tigris/tigris.yaml
-2. $HOME/.tigris/tigris.yaml
-3. ./config/tigris.yaml
-4. ./tigris.yaml
+1. /etc/tigris/tigris-cli.yaml
+2. $HOME/.tigris/tigris-cli.yaml
+3. ./config/tigris-cli.yaml
+4. ./tigris-cli.yaml
 
 ### Example configuration file
 
-Here is an example of tigris.yaml:
+Here is an example of tigris-cli.yaml:
 
 ```yaml
 url: tigris.example.com:8081


### PR DESCRIPTION
This PR will fix two problem:

1. The Go quickstart is now broken
2. The default config file name for `tigris-cli`  is changed to `tigris-cli.yaml`